### PR TITLE
new_body_parser

### DIFF
--- a/lib/translate.js
+++ b/lib/translate.js
@@ -64,7 +64,7 @@ var runTranslation = function() {
   /* Performing the request */
   request(targetURL, function(error, response, body) {
       if (!error && response.statusCode == 200) {
-        /* JSON.parse() doesn't work (empty values in array)
+        /* Outdated: JSON.parse() doesn't work (empty values in array)
         Retrieved results from Google's server:
         [[["Hola Mundo","Hello World",,,1]],,"en"]
         Parsed results (with language name):
@@ -74,9 +74,8 @@ var runTranslation = function() {
           sourceLang: { code: 'en', language: 'English' },
           targetLang: { code: 'es', language: 'Spanish' }
         } */
-        /* Delete empty fields */
-        var Intermed = body.replace(/,{1,}/g, ',');
-        /* now, JSON.parse() works */
+        /* JSON.parse works but we delete null fields */
+        var Intermed = body.replace(/,null{1,}/g, '');
         var Values = JSON.parse(Intermed);
         var Sentences = Values[0];
         var results = {};


### PR DESCRIPTION
There were problems with some option (such as -d), the body in the request has changed: Since April 2017, empty fields have been replaced by null fields so that JSON.parse() could work directly with this new body.
This commit take this into account.