### PR TITLE
Add ability to specify defaults using environment variables.

### DIFF
--- a/lib/translate.js
+++ b/lib/translate.js
@@ -6,6 +6,18 @@ var program = require('commander');
 var request = require('request');
 var URL = require('url');
 var languages = require('./languages');
+
+var defaultSource = process.env.ja_gtc_source
+var defaultTarget = process.env.ja_gtc_target
+if (defaultSource === undefined) defaultSource = 'en'
+if (defaultTarget === undefined) defaultTarget = 'es'
+if (defaultSource === defaultTarget) {
+	console.log('Error, environment variables "ja_gtc_source" and "ja_gtc_target" are set to the same value.')
+	console.log('Proceeding using default values.')
+	defaultSource = 'en'
+	defaultTarget = 'es'
+}
+
 /* Supported languages: https://cloud.google.com/translate/v2/translate-reference#supported_languages */
 
 /* This function creates the URL to get the translation from Google's server
@@ -36,8 +48,8 @@ program
   /* TODO: Create defaults and let users change them [auto, source, target] */
   .option('-d, --details', 'View details')
   .option('-l, --list', 'List all available languages')
-  .option('-s, --source [language]', 'Source language [en]', new RegExp(languages.getLanguagesCodesRegex(), 'i'), 'en')
-  .option('-t, --target [language]', 'Target language [es]', new RegExp(languages.getLanguagesCodesRegex(), 'i'), 'es')
+  .option('-s, --source [language]', 'Source language [en]', new RegExp(languages.getLanguagesCodesRegex(), 'i'), defaultSource)
+  .option('-t, --target [language]', 'Target language [es]', new RegExp(languages.getLanguagesCodesRegex(), 'i'), defaultTarget)
   .on('--help', function () {
     console.log('  Examples:\n');
     console.log("     $ translate 'I want to translate this text'");

--- a/lib/translate.js
+++ b/lib/translate.js
@@ -7,12 +7,12 @@ var request = require('request');
 var URL = require('url');
 var languages = require('./languages');
 
-var defaultSource = process.env.ja_gtc_source
-var defaultTarget = process.env.ja_gtc_target
+var defaultSource = process.env.JA_GTC_SOURCE
+var defaultTarget = process.env.JA_GTC_TARGET
 if (defaultSource === undefined) defaultSource = 'en'
 if (defaultTarget === undefined) defaultTarget = 'es'
 if (defaultSource === defaultTarget) {
-	console.log('Error, environment variables "ja_gtc_source" and "ja_gtc_target" are set to the same value.')
+	console.log('Error, environment variables "JA_GTC_SOURCE" and "JA_GTC_TARGET" are set to the same value.')
 	console.log('Proceeding using default values.')
 	defaultSource = 'en'
 	defaultTarget = 'es'


### PR DESCRIPTION
Hey, I noticed on your TODO you wanted to provide the option for users to specify the default languages. Well, I guess this isn't quite what you wanted, but I added the ability for users to use environment variables to set defaults. I didn't want to change too much code in this commit, so I kept it simple.