### PR TITLE
Bugfix-- Remove problematic error message

### DIFF
--- a/lib/translate.js
+++ b/lib/translate.js
@@ -11,12 +11,6 @@ var defaultSource = process.env.JA_GTC_SOURCE
 var defaultTarget = process.env.JA_GTC_TARGET
 if (defaultSource === undefined) defaultSource = 'en'
 if (defaultTarget === undefined) defaultTarget = 'es'
-if (defaultSource === defaultTarget) {
-	console.log('Error, environment variables "JA_GTC_SOURCE" and "JA_GTC_TARGET" are set to the same value.')
-	console.log('Proceeding using default values.')
-	defaultSource = 'en'
-	defaultTarget = 'es'
-}
 
 /* Supported languages: https://cloud.google.com/translate/v2/translate-reference#supported_languages */
 


### PR DESCRIPTION
Sorry to ask for a PR again so soon-- but I found a bug in my code. 

In my original code, I checked to see if the default values were equal to each other, and then logged an error to the console. It turns out, there are a number of edge cases where that resulted in unexpected behavior.

I decided to remove the check entirely, to bring it more in line with the original behavior of the app, like how if -t and -s are both 'es' then the app fails gracefully-- it follows the behavior should be the same when environment variables are used.